### PR TITLE
Fix for multi line <pre><code>... blocks

### DIFF
--- a/source/css/_partial/article.styl
+++ b/source/css/_partial/article.styl
@@ -149,7 +149,6 @@ article
       font-family font-mono
 
     code
-      white-space nowrap
       background #eee
       color #666
       padding 0 5px


### PR DESCRIPTION
Without this change, the formatting of <pre>  is currently broken for multiline blocks, example:

``` yaml
test:
  - foo
  - bar
```

would be formatted in the html as:

`yaml test: - foo - bar`
