### PR TITLE
Fix meta viewport warnings

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -26,7 +26,7 @@
   <meta name="description" content="<%= strip_html(page.content).replace(/^\s*/, '').replace(/\s*$/, '').substring(0, 150) %>">
   <% } %>
   <% if (page.keywords){ %><meta name="keywords" content="<%= page.keywords %>"><% } %>
-  <meta name="viewport" content="width=device-width; initial-scale=1; maximum-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 
   <% if (page.title){ %><meta property="og:title" content="<%= page.title %>"/><% } %>
   <meta property="og:site_name" content="<%= config.title %>"/>


### PR DESCRIPTION
Using ; to separate viewport meta contents will generate the following
error:

Viewport argument value "device-width;" for key "width" not recognized.
Content ignored.

Use , instead fixes that:
http://royaltutorials.com/viewport-argument-value-device-width-for-key-width-not-recognized-content-ignored/
