### PR TITLE
Update clone URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Default theme for [Hexo].
 Execute the following command and modify `theme` in `_config.yml` to `light`.
 
 ```
-git clone git://github.com/tommy351/hexo-theme-light.git themes/light
+git clone git@github.com:tommy351/hexo-theme-light.git themes/light
 ```
 
 ## Update


### PR DESCRIPTION
The old `git://` will raise this error:

```
$ git clone git://github.com/tommy351/hexo-theme-light.git themes/light
Cloning into 'themes/light'...
fatal: read error: Connection reset by peer
```
