### PR TITLE
Add an escaping class attribute for fancybox.

### DIFF
--- a/source/js/gallery.js
+++ b/source/js/gallery.js
@@ -2,7 +2,7 @@
   // Caption
   $('.entry').each(function(i){
     $(this).find('img').each(function(){
-      if (!this.find('nofancybox')){
+      if (!$(this).hasClass('nofancybox')){
         var alt = this.alt;
 
         if (alt){


### PR DESCRIPTION
Add an escaping class attribute `nofancybox` for fancybox.

Now all `img` tags with class `nofancybox` that would normally get auto-enabled, will be excluded from opening in a FancyBox overlay.

```
<a href="url/to/fullimg.jpg"><img src="url/to/thumbnail.jpg" class="nofancybox"/></a>
```
