### PR TITLE
Do not generate gallery markup if no photos

### DIFF
--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -1,5 +1,5 @@
 <article class="<%= item.layout %>">
-  <% if (item.photos){ %>
+  <% if (item.photos && item.photos.length){ %>
     <%- partial('post/gallery') %>
   <% } %>
   <div class="post-content">


### PR DESCRIPTION
I think that since the `photos` property has been added to the post model, it is an empty array instead of no array at all. 
In the light theme, it generates the markup for the gallery even if it is not needed. I've added a length check.
