### PR TITLE
Added Google Analytics option for "domain"

### DIFF
--- a/layout/_partial/google_analytics.ejs
+++ b/layout/_partial/google_analytics.ejs
@@ -2,6 +2,9 @@
 <script type="text/javascript">
   var _gaq = _gaq || [];
   _gaq.push(['_setAccount', '<%= theme.google_analytics %>']);
+  <% if (theme.google_analytics_domain){ %>
+  _gaq.push(['_setDomainName', '<%= theme.google_analytics_domain %>']);
+  <% } %>
   _gaq.push(['_trackPageview']);
 
   (function() {


### PR DESCRIPTION
If you have multiple domains under the same Google analytics account, you must provide your domain in the  GA init code.
If added a theme option for this.

In _config.yml:

```
google_analytics: UA-YOUR-GA-ID
google_analytics_domain: yourdomain.com
```
