### PR TITLE
Clean up behavior when no comment provider specified.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+*.swp
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ facebook:
 
 ### Gallery Post
 
-![](http://i4.minus.com/ibp6Hbytwgof9y.jpg)
 
 ```
 ---
@@ -103,8 +102,6 @@ photos:
 
 ### Link Post
 
-![](http://i3.minus.com/i7hBbGqh14EWo.png)
-
 ```
 ---
 layout: link
@@ -115,11 +112,9 @@ link: http://www.google.com/
 
 ### Tweet Widget
 
-![](http://i1.minus.com/iMC8EyF9y0Y3y.PNG)
 
 ### Fancybox
 
-![](http://i4.minus.com/iHv7h7rZNqHvo.PNG)
 
 [Hexo]: http://hexo.io
 [AddThis]: https://www.addthis.com

--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ fancybox: true
 
 google_analytics:
 rss:
+
+comment_provider: facebook
+facebook:
+  appid: 012345012345
+  comment_count: 5
+  comment_width: 840
+  comment_colorscheme: light
 ```
 
 - **menu** - Main navigation menu
@@ -72,12 +79,17 @@ rss:
 - **fancybox** - Enable [Fancybox]
 - **google_analytics** - Google Analytics ID
 - **rss** - RSS subscription link (change if using Feedburner)
-
+- **comment_provider** - "facebook" (to enable Facebook comments)
+  - **appid** - Facebook AppId (from developer tools)
+  - **comment_count** - Number of commends to show
+  - **comment_width** - Width of comment box in pixels
+  - **comment_colorscheme** - Color scheme
+ 
 ## Features
 
 ### Gallery Post
 
-![](http://i.minus.com/ibp6Hbytwgof9y.jpg)
+![](http://i4.minus.com/ibp6Hbytwgof9y.jpg)
 
 ```
 ---
@@ -91,7 +103,7 @@ photos:
 
 ### Link Post
 
-![](http://i.minus.com/i7hBbGqh14EWo.png)
+![](http://i3.minus.com/i7hBbGqh14EWo.png)
 
 ```
 ---
@@ -103,12 +115,12 @@ link: http://www.google.com/
 
 ### Tweet Widget
 
-![](http://i.minus.com/iMC8EyF9y0Y3y.PNG)
+![](http://i1.minus.com/iMC8EyF9y0Y3y.PNG)
 
 ### Fancybox
 
-![](http://i.minus.com/iHv7h7rZNqHvo.PNG)
+![](http://i4.minus.com/iHv7h7rZNqHvo.PNG)
 
-[Hexo]: http://zespia.tw/hexo/
+[Hexo]: http://hexo.io
 [AddThis]: https://www.addthis.com
 [Fancybox]: http://fancyapps.com/fancybox/

--- a/_config.yml
+++ b/_config.yml
@@ -27,10 +27,10 @@ fancybox: true
 google_analytics:
 rss:
 
-# Facebook comment
-#comment_provider: facebook
+# Uncomment the line below to enable facebook commenting 
+# comment_provider: facebook
 facebook:
-  appid: 1627819517467507
+  appid: #012345012345 override with your AppId
   comment_count: 5
   comment_width: 840
   comment_colorscheme: light

--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,7 @@ widgets:
 - search
 - category
 - tag
+- twitter
 
 excerpt_link: Read More
 
@@ -27,10 +28,9 @@ fancybox: true
 google_analytics:
 rss:
 
-# Uncomment the line below to enable facebook commenting 
 # comment_provider: facebook
 facebook:
-  appid: #012345012345 override with your AppId
+  appid: 012345012345
   comment_count: 5
   comment_width: 840
   comment_colorscheme: light

--- a/_config.yml
+++ b/_config.yml
@@ -27,10 +27,10 @@ fancybox: true
 google_analytics:
 rss:
 
-comment_provider: facebook
 # Facebook comment
+#comment_provider: facebook
 facebook:
-  appid: 123456789012345
+  appid: 1627819517467507
   comment_count: 5
   comment_width: 840
   comment_colorscheme: light

--- a/languages/en.yml
+++ b/languages/en.yml
@@ -1,0 +1,12 @@
+categories: Categories
+search: Search
+tags: Tags
+tagcloud: Tag Cloud
+tweets: Tweets
+prev: Prev
+next: Next
+comment: Comments
+archive_a: Archives
+archive_b: "Archives: %s"
+page: Page %d
+recent_posts: Recent Posts

--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -24,7 +24,7 @@
             <a href="<%- config.root %><%- item.path %>#more" class="more-link"><%= theme.excerpt_link %></a>
           </div>
         <% } %>
-        <% if (item.comment && config.disqus_shortname){ %>
+        <% if (item.comments && config.disqus_shortname){ %>
         <div class="alignright">
           <a href="<%- item.permalink %>#disqus_thread" class="comment-link">Comments</a>
         </div>
@@ -39,4 +39,6 @@
   </div>
 </article>
 
+<% if (item.comments && (config.disqus_shortname || theme.comment_provider == "facebook")){ %>
 <%- partial('comment') %>
+<% } %>


### PR DESCRIPTION
If a site does not specify either a disqus or Facebook comment provider, individual posts are still rendered with an empty comment box. This is fixed in this pull request.

A site that specified 'en' as language would still use the 'tw' language local files. Add a `en.yml` locale file.

Update documentation in the readme. 

In the longer term it would be good to get per-site configurations out of the theme and moved into to `site/_config.yml`