### PR TITLE
Added fragment_cache to sidebar

### DIFF
--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -4,7 +4,7 @@
   <header id="header" class="inner"><%- partial('_partial/header') %></header>
   <div id="content" class="inner">
     <div id="main-col" class="alignleft"><div id="wrapper"><%- body %></div></div>
-    <aside id="sidebar" class="alignright"><%- partial('_partial/sidebar') %></aside>
+    <aside id="sidebar" class="alignright"><%- partial('_partial/sidebar', {}, {cache: true}) %></aside>
     <div class="clearfix"></div>
   </div>
   <footer id="footer" class="inner"><%- partial('_partial/footer') %></footer>


### PR DESCRIPTION
As discussed in issue #57, `tag` and `tagcloud` widgets slow down generation a lot, @leesei pointed out in this issue https://github.com/hexojs/hexo/issues/1769 that using `fragment_cache` would speed up the process, and as a matter of fact, it dramatically reduces generation time.