### PR TITLE
fixed google search widget

### DIFF
--- a/layout/_widget/search.ejs
+++ b/layout/_widget/search.ejs
@@ -1,6 +1,6 @@
 <div class="search">
   <form action="//google.com/search" method="get" accept-charset="utf-8">
     <input type="search" name="q" results="0" placeholder="<%= __('search') %>">
-    <input type="hidden" name="q" value="site:<%- config.url.replace(/^https?:\/\//, '') %>">
+    <input type="hidden" name="as_sitesearch" value="<%- config.url.replace(/^https?:\/\//, '') %>">
   </form>
 </div>


### PR DESCRIPTION
The `search` widget wasn't actually working, `q` was overwritten by the site name. There's a dedicated keyword to narrow the search to a specific web site: `as_sitesearch`. That's what this commit is about.
