### PR TITLE
fix(seo): use valid schema and add microformat

### DIFF
--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -1,4 +1,4 @@
-<article class="<%= item.layout %>">
+<article id="<%= item.layout %>-<%= item.slug %>" class="h-entry <%= item.layout %>" itemprop="blogPost" itemscope itemtype="https://schema.org/BlogPosting">
   <% if (item.photos && item.photos.length){ %>
     <%- partial('post/gallery') %>
   <% } %>
@@ -6,11 +6,11 @@
     <header>
       <% if (item.layout != 'page'){ %>
         <div class="icon"></div>
-        <time datetime="<%= item.date.toDate().toISOString() %>"><a href="<%- config.root %><%- item.path %>"><%= item.date.format(config.date_format) %></a></time>
+        <time class="dt-published" datetime="<%= item.date.toDate().toISOString() %>"><a href="<%- config.root %><%- item.path %>"><%= item.date.format(config.date_format) %></a></time>
       <% } %>
       <%- partial('post/title') %>
     </header>
-    <div class="entry">
+    <div class="e-content entry" itemprop="articleBody">
       <% if (item.excerpt && index){ %>
         <%- item.excerpt %>
       <% } else { %>

--- a/layout/_partial/post/title.ejs
+++ b/layout/_partial/post/title.ejs
@@ -8,6 +8,6 @@
   <% if (index){ %>
     <h1 class="title"><a href="<%- config.root %><%- item.path %>"><%= item.title %></a></h1>
   <% } else { %>
-    <h1 class="title"><%= item.title %></h1>
+    <h1 class="p-name title" itemprop="headline name"><%= item.title %></h1>
   <% } %>
 <% } %>


### PR DESCRIPTION
This fix the `Unspecified type` schema issue identified by [Google](https://search.google.com/structured-data/testing-tool/).

`headline` class is only added to post title in an article, not archive/index.

Add [h-entry](http://microformats.org/wiki/h-entry) Microformat.

schema fix is based on [this example](https://github.com/philwareham/schema-microdata-examples/blob/master/blog.html).