### PR TITLE
chore: use GitHub actions to deploy preview site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,71 @@
+name: Deploy preview site
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: [$default-branch]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+# Default to bash
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: hexojs/hexo-theme-unit-test
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install Dependencies
+        run: npm install
+      - name: Set theme and url
+        run: |
+          npx hexo config theme light
+          npx hexo config url https://hexojs.github.io/hexo-theme-light/
+      - name: Checkout latest theme
+        uses: actions/checkout@v4
+        with:
+          path: themes/light
+      - name: Build with Hexo
+        run: npx hexo g
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./public
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Currently, the light theme uses GitHub Pages (https://hexojs.github.io/hexo-theme-light/) for publishing previews, but this process requires manual intervention and has not been updated for many years. By switching to GitHub Actions, we can automate the build of the latest preview site.
