### PR TITLE
feat: read disqus_shortname from theme config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy preview site
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: [$default-branch]
+    branches: [master]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/_config.yml
+++ b/_config.yml
@@ -21,9 +21,11 @@ google_analytics:
 rss:
 
 comment_provider: facebook
+# Disqus comment
+disqus_shortname:
 # Facebook comment
 facebook:
-  appid: 123456789012345
+  appid: # <appId>
   comment_count: 5
   comment_width: 840
   comment_colorscheme: light

--- a/layout/_partial/after_footer.ejs
+++ b/layout/_partial/after_footer.ejs
@@ -2,9 +2,9 @@
 <%- js('js/jquery.imagesloaded.min.js') %>
 <%- js('js/gallery.js') %>
 
-<% if (config.disqus_shortname){ %>
+<% if (theme.disqus_shortname){ %>
 <script>
-var disqus_shortname = '<%= config.disqus_shortname %>';
+var disqus_shortname = '<%= theme.disqus_shortname %>';
 
 (function(){
   var dsq = document.createElement('script');

--- a/layout/_partial/article.ejs
+++ b/layout/_partial/article.ejs
@@ -24,7 +24,7 @@
             <a href="<%- url_for(item.path) %>#more" class="more-link"><%= theme.excerpt_link %></a>
           </div>
         <% } %>
-        <% if (item.comment && config.disqus_shortname){ %>
+        <% if (item.comments && theme.disqus_shortname){ %>
         <div class="alignright">
           <a href="<%- item.permalink %>#disqus_thread" class="comment-link">Comments</a>
         </div>

--- a/layout/_partial/comment.ejs
+++ b/layout/_partial/comment.ejs
@@ -6,7 +6,7 @@
       if (theme.facebook) { %>
       <%- partial('_partial/facebook_comment', {fbConfig: theme.facebook}) %>
       <% } %>
-  <% } else if(config.disqus_shortname) { %>
+  <% } else if(theme.disqus_shortname) { %>
   <div id="disqus_thread">
     <noscript>Please enable JavaScript to view the <a href="//disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
   </div>


### PR DESCRIPTION
In earlier versions of Hexo, themes needed to read the `disqus_shortname` from Hexo's `_config.yml` file as the configuration for the Disqus comment system. However, this option was deprecated around 2015 (https://github.com/hexojs/hexo-theme-unit-test/commit/8dd691e). Nowadays, many themes allow users to load different Disqus configuration options, and there are no unified regulations for this. Therefore, I plan to move the `disqus_shortname` option for the official Hexo theme from the Hexo configuration file to the theme configuration file.