### PR TITLE
Pagination on the Archive pages as well as the Index page

### DIFF
--- a/layout/_partial/archive.ejs
+++ b/layout/_partial/archive.ejs
@@ -14,7 +14,6 @@ if (page.archive){
     <%- partial('article', {item: item, index: true}) %>
   <% }); %>
 
-  <%- partial('pagination') %>
 <% } else { %>
   <div class="archive">
     <% page.posts.each(function(item){ %>
@@ -38,3 +37,5 @@ if (page.archive){
     <% }); %>
   </div>
 <% } %>
+
+<%- partial('pagination') %>


### PR DESCRIPTION
## Problem
Currently there is no pagination on the Archive pages.  
When there are more posts in a month than the pagination amount, some posts cannot be viewed in the Archive.  

## Example
In the below demo there are 100 posts. One post per day.

Only the first `per_page` posts (10 in this demo) are visible on each Archive page.  
This means it is not possible to view all posts in a month:    
![Only 10 posts visible per month](https://github.com/user-attachments/assets/3f6067a5-1332-4c91-b301-21fd220f27b1)


## Changes
This change makes pagination visible on the Archive pages:
![Archive pagination](https://github.com/user-attachments/assets/48903735-bb4d-4185-b850-843270e24a90)
