### PR TITLE
feat: remove pagination variable

### DIFF
--- a/layout/_partial/archive.ejs
+++ b/layout/_partial/archive.ejs
@@ -9,33 +9,26 @@ if (page.archive){
 %>
 <h2 class="archive-title<% if (page.tag){ %> tag<% } else if (page.category){ %> category<% } %>"><%= title %></h2>
 
-<% if (pagination == 2){ %>
+<div class="archive">
   <% page.posts.each(function(item){ %>
-    <%- partial('article', {item: item, index: true}) %>
-  <% }); %>
-
-<% } else { %>
-  <div class="archive">
-    <% page.posts.each(function(item){ %>
-      <article class="<%= item.layout %>">
-        <div class="post-content">
-          <header>
-            <div class="icon"></div>
-            <time datetime="<%= item.date.toDate().toISOString() %>"><a href="<%- url_for(item.path) %>"><%= item.date.format(config.date_format) %></a></time>
-            <% if (item.link){ %>
-              <% if (item.title){ %>
-                <h1 class="title link"><a href="<%- item.link %>" target="_blank"><%= item.title %></a></h1>
-              <% } else { %>
-                <h1 class="title link"><a href="<%- item.link %>" target="_blank"><%= item.link %></a></h1>
-              <% } %>
+    <article class="<%= item.layout %>">
+      <div class="post-content">
+        <header>
+          <div class="icon"></div>
+          <time datetime="<%= item.date.toDate().toISOString() %>"><a href="<%- url_for(item.path) %>"><%= item.date.format(config.date_format) %></a></time>
+          <% if (item.link){ %>
+            <% if (item.title){ %>
+              <h1 class="title link"><a href="<%- item.link %>" target="_blank"><%= item.title %></a></h1>
             <% } else { %>
-              <h1 class="title"><a href="<%- url_for(item.path) %>"><%= item.title %></a></h1>
+              <h1 class="title link"><a href="<%- item.link %>" target="_blank"><%= item.link %></a></h1>
             <% } %>
-          </header>
-        </div>
-      </article>
-    <% }); %>
-  </div>
-<% } %>
+          <% } else { %>
+            <h1 class="title"><a href="<%- url_for(item.path) %>"><%= item.title %></a></h1>
+          <% } %>
+        </header>
+      </div>
+    </article>
+  <% }); %>
+</div>
 
 <%- partial('pagination') %>

--- a/layout/archive.ejs
+++ b/layout/archive.ejs
@@ -1,1 +1,1 @@
-<%- partial('_partial/archive', {pagination: config.archive}) %>
+<%- partial('_partial/archive') %>

--- a/layout/category.ejs
+++ b/layout/category.ejs
@@ -1,1 +1,1 @@
-<%- partial('_partial/archive', {pagination: config.category}) %>
+<%- partial('_partial/archive') %>

--- a/layout/tag.ejs
+++ b/layout/tag.ejs
@@ -1,1 +1,1 @@
-<%- partial('_partial/archive', {pagination: config.tag}) %>
+<%- partial('_partial/archive') %>


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo!
-->

## check list

- [ ] Add test cases for the changes.
- [x] Passed the CI test.

## Description

Hexo once had a configuration option like `archive: 2`, but it was removed ten years ago (in https://github.com/hexojs/hexo/commit/72ff6ac9f2f80b4ae32aeed014a859bd5e6be4ea). In the Light theme, if `archive: 2` was set, the pagination attribute of the archive page would be affected. However, today this `if` condition will no longer be satisfied, so it should be deleted.

## Additional information
